### PR TITLE
Adding import and trying to fix TcpStream errors

### DIFF
--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -15,3 +15,5 @@ chrono = { version = "0.4", features = ["serde"] }
 prost-types = "0.13.4"
 rafka-storage = { path = "../storage" }
 bytes = "1.4"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.216", features = ["derive"] }

--- a/crates/consumer/Cargo.toml
+++ b/crates/consumer/Cargo.toml
@@ -11,3 +11,5 @@ uuid = { version = "1.3", features = ["v4"] }
 futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 prost-types = "0.11"
+serde_json = "1.0.134"
+serde = "1.0.216"

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,4 +1,0 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("src/proto/rafka.proto")?;
-    Ok(())
-} 

--- a/crates/core/src/message.rs
+++ b/crates/core/src/message.rs
@@ -1,6 +1,6 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {

--- a/crates/producer/Cargo.toml
+++ b/crates/producer/Cargo.toml
@@ -10,3 +10,5 @@ tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.3", features = ["v4"] }
 futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0.216", features = ["derive"] }
+serde_json = "1.0.134"


### PR DESCRIPTION
tokio doesnt implement try_clone(), so i tried to convert to std::TcpStream to use the try_clone, but it consumes the value of TcpStream and then comes some Ownership problems that i won't fix (at least rn) because im going to sleep.

I think the TcpStream will need to be behind an Arc<Mutex<>> to work properly